### PR TITLE
Add DisplayName functionality

### DIFF
--- a/samples/Hangfire.Microservices.NewsletterService/NewsletterSender.cs
+++ b/samples/Hangfire.Microservices.NewsletterService/NewsletterSender.cs
@@ -5,6 +5,8 @@ namespace Hangfire.Microservices.NewsletterService
     [Queue("newsletter")]
     public sealed class NewsletterSender
     {
+
+        [JobDisplayName("Newsletter {0}")]
         public static void Execute(long campaignId)
         {
             Console.WriteLine($"Processing newsletter '{campaignId}'");

--- a/samples/Hangfire.Microservices.OrdersService/OrderSubmitter.cs
+++ b/samples/Hangfire.Microservices.OrdersService/OrderSubmitter.cs
@@ -2,8 +2,10 @@ using System;
 
 namespace Hangfire.Microservices.OrdersService
 {
+    [Queue("orders")]
     public class OrderSubmitter
     {
+        [JobDisplayName("order {0} - status {1}")]
         public void Execute(long orderId, string status)
         {
             Console.WriteLine($"Submitting order {orderId} with status {status}");

--- a/src/Hangfire.DynamicJobs/DynamicJob.cs
+++ b/src/Hangfire.DynamicJobs/DynamicJob.cs
@@ -17,13 +17,15 @@ namespace Hangfire
             [NotNull] string method,
             [CanBeNull] string parameterTypes,
             [CanBeNull] string args,
-            [CanBeNull] JobFilterAttribute[] filters)
+            [CanBeNull] JobFilterAttribute[] filters,
+            [CanBeNull] JobDisplayNameAttribute displayName)
         {
             Type = type ?? throw new ArgumentNullException(nameof(type));
             Method = method ?? throw new ArgumentNullException(nameof(method));
             ParameterTypes = parameterTypes;
             Args = args;
             Filters = filters;
+            DisplayName = displayName;
         }
 
         [NotNull]
@@ -45,6 +47,11 @@ namespace Hangfire
         [CanBeNull]
         [JsonProperty("f",  NullValueHandling = NullValueHandling.Ignore, ItemTypeNameHandling = TypeNameHandling.Auto)]
         public JobFilterAttribute[] Filters { get; }
+
+        //TODO: Check if is better save display name as resolved string (maybe when you use location resources can be cause crash?)
+        [CanBeNull]
+        [JsonProperty("dn", NullValueHandling = NullValueHandling.Ignore, ItemTypeNameHandling = TypeNameHandling.Auto)]
+        public JobDisplayNameAttribute DisplayName { get; }
 
         [PublicAPI]
         [DynamicJobDisplayName]

--- a/src/Hangfire.DynamicJobs/DynamicJobDisplayNameAttribute.cs
+++ b/src/Hangfire.DynamicJobs/DynamicJobDisplayNameAttribute.cs
@@ -2,6 +2,7 @@
 // Please see the LICENSE file for the licensing details.
 
 using System;
+using System.Globalization;
 using Hangfire.Annotations;
 using Hangfire.Common;
 using Hangfire.Dashboard;
@@ -23,6 +24,13 @@ namespace Hangfire
             {
                 if (arg is DynamicJob dynamicJob)
                 {
+                    //create display name from JobDisplayNameAttribute
+                    if (dynamicJob.DisplayName != null)
+                    {
+                        var displayName = GenerateDisplayName(dynamicJob);
+                        return displayName;
+                    }
+
                     return $"Dynamic: {ExtractTypeName(dynamicJob.Type, out _, out _)}.{dynamicJob.Method}";
                 }
             }
@@ -60,5 +68,26 @@ namespace Hangfire
 
             return type;
         }
+
+
+
+        internal static string GenerateDisplayName(DynamicJob job)
+        {
+
+            var text = job.DisplayName.DisplayName;
+
+            //code from format method of JobDisplayNameAttribute with private properties (cache/resources)
+            //if (ResourceType != null)
+            //{
+            //    text = _resourceManagerCache.GetOrAdd(ResourceType, InitResourceManager).GetString(DisplayName, CultureInfo.CurrentUICulture);
+            //    if (string.IsNullOrEmpty(text))
+            //    {
+            //        text = DisplayName;
+            //    }
+            //}
+            string[] arguments = SerializationHelper.Deserialize<string[]>(job.Args);
+            return string.Format(CultureInfo.CurrentCulture, text, arguments);
+        }
+
     }
 }


### PR DESCRIPTION
I am sending you this pull request as a POC to add the functionality already present in hangfire to modify the DisplayName of the job in the dashboard using the appropriate attribute.

In the commits I added the DisplayName property to the DynamicJob object so that it is serialized and deserialized.
You will also find comments, on a possible alternative way (i.e. to resolve the display name at creation time)

Feel free to refuse the pull request and rewrite the code as you like, I thought it was more convenient to send you an example rather than a simple issue on the main hangfire repo.